### PR TITLE
WIP: attempt rendering directly in Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/frioux/love-letter
 
 go 1.19
+
+require (
+	github.com/fogleman/gg v1.3.0 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	golang.org/x/image v0.5.0 // indirect
+)


### PR DESCRIPTION
The idea here was to use a language more efficient than Python to render the actual text, with the hope being that it would then run faster on the device.  Sadly, while I can render the text well, I cannot seem to get it monochrome nicely.  [I believe this is the relevant python](https://github.com/PiSupply/PaPiRus/blob/68e7afa/papirus/epd.py#L175-L183):

```python
    def display(self, image):

        # attempt grayscale conversion, and then to single bit
        # better to do this before calling this if the image is to
        # be dispayed several times
        if image.mode != "1":
            image = ImageOps.grayscale(image).convert("1", dither=Image.FLOYDSTEINBERG)
```

I tried to port this to Go (the grayscale step doesn't visually make any difference):
```golang
	l := image.NewGray(image.Rect(0, 0, 200, 96))

	draw.FloydSteinberg.Draw(l, l.Bounds(), c.Image(), image.ZP)
	i := image.NewPaletted(image.Rect(0, 0, 200, 96), color.Palette{color.Black, color.White})

	draw.FloydSteinberg.Draw(i, i.Bounds(), l, image.ZP)
```

Here's the Python generated image: 
![image](https://user-images.githubusercontent.com/8163/221628476-7fceb291-c1a2-4d7f-b3b0-0c732d7ad285.png)

Here's what I get from the current go:
![image](https://user-images.githubusercontent.com/8163/221628540-6cc8c3ad-ba33-413b-a046-a064e8cc2e82.png)


I also tried making a derpy little thing where any pixel that wasn't white would become fully black.  Also didn't turn out looking right:
```golang
	i := image.NewGray(image.Rect(0, 0, 200, 96))
	for x := i.Rect.Min.X; x < i.Rect.Max.X; x++ {
		for y := i.Rect.Min.Y; y < i.Rect.Max.Y; y++ {
			c := c.Image().At(x, y)
			if c == color.White {
				i.Set(x, y, c)
			} else {
				i.Set(x, y, color.Black)
			}
		}
	}
```

![image](https://user-images.githubusercontent.com/8163/221628669-01010b8d-f102-49e5-b1d1-d57730396f66.png)
